### PR TITLE
Update record_model.ts

### DIFF
--- a/src/core/record_model.ts
+++ b/src/core/record_model.ts
@@ -69,22 +69,19 @@ export class Record {
     this.#isNew = isNew;
 
     if (isNew) {
-      for (const field of collection.Fields) {
-        const name = field.GetName();
-        if (name === FieldNameId) {
-          continue;
-        }
-        const prepared = field.PrepareValue(this, null);
-        if (!Object.prototype.hasOwnProperty.call(this.#originalData, name)) {
-          this.#originalData[name] = prepared;
-        }
-        // Deviation: mirror defaults into #data to emulate Go's store.GetOk fallback behavior.
-        if (!Object.prototype.hasOwnProperty.call(this.#data, name)) {
-          this.#data[name] = prepared;
-        }
-      }
-    }
-  }
+     for (const field of collection.Fields) {
+             const name = field.GetName();
+             if (name === FieldNameId) {
+                     continue;
+             }
+             const rawValue = Object.prototype.hasOwnProperty.call(this.#data, name)
+                     ? this.#data[name]
+                     : null;
+             const prepared = field.PrepareValue(this, rawValue);
+             this.#originalData[name] = prepared;
+             this.#data[name] = prepared;
+     }
+}
 
   collection(): Collection {
     return this.#collection;


### PR DESCRIPTION
## Problem

When creating a new record with initial data, e.g.:

const user = new Record(collection, {
  email: "user@example.com",
  password: "secret123",
  username: "john",
});

fields that are present in data are stored as-is. They never go through field.PrepareValue(). As a result:
Password field: expects an internal PasswordFieldValue instance. With a plain string stored, ValidateValue() fails with ErrUnsupportedValueType ("Invalid or unsupported value type.") because record.GetRaw("password") is a string, not PasswordFieldValue.
Other field types that normalize or wrap values in PrepareValue also behave incorrectly when values are passed in the constructor.
Currently, only fields missing from data get PrepareValue(this, null) when isNew is true. Fields present in data are left raw.
Solution
When isNew is true, run PrepareValue(this, rawValue) for every field (except id), using the value from data when present and null otherwise. Then store the prepared value in both #data and #originalData. This matches the behavior of creating an empty record and calling record.set(field, value) for each field.
Changes
src/core/record_model.ts: In the Record constructor, for each field (when isNew), use the existing value from #data (or null if absent) as the argument to PrepareValue, and always assign the prepared result to #originalData and #data.